### PR TITLE
Rescue if path not found

### DIFF
--- a/lib/carrierwave/storage/dropbox.rb
+++ b/lib/carrierwave/storage/dropbox.rb
@@ -44,8 +44,12 @@ module CarrierWave
         end
 
         def url
-          metadata, result = @client.get_temporary_link("/#{@path}")
-          result
+          begin
+            metadata, result = @client.get_temporary_link("/#{@path}")
+            result
+          rescue ::Dropbox::ApiError
+            ""
+          end
         end
 
         def delete


### PR DESCRIPTION
I'm not sure of the best way to handle files deleted upstream, but I suppose a rescue from PathNotFound error is at least a start.

Probably needs an error message too!
